### PR TITLE
Crash/Exception when attempting to copy and paste an array/dictionary node

### DIFF
--- a/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListEditor.m
+++ b/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListEditor.m
@@ -937,8 +937,8 @@
 		return;
 	}
 	
-	LNPropertyListNode* node = [_outlineView itemAtRow:row];
-	
+	LNPropertyListNode* node = [[_outlineView itemAtRow:row] copy];
+
 	id<NSPasteboardWriting> pbWriter = node.pasteboardWriter;
 	
 	[NSPasteboard.generalPasteboard clearContents];

--- a/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListEditor.m
+++ b/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListEditor.m
@@ -91,9 +91,9 @@
 	
 	_outlineView.enclosingScrollView.translatesAutoresizingMaskIntoConstraints = NO;
 	
-	[_outlineView registerForDraggedTypes:@[LNPropertyListNodePasteboardType]];
 	[_outlineView setDraggingSourceOperationMask:NSDragOperationCopy forLocal:NO];
 	
+	[_outlineView registerForDraggedTypes:@[LNPropertyListNodePasteboardReferenceType]];
 	[_outlineView setTarget:self];
 	[_outlineView setAction:@selector(_outlineViewSingleClick)];
 	[_outlineView setDoubleAction:@selector(_outlineViewDoubleClick)];
@@ -657,7 +657,7 @@
 
 - (BOOL)_validateCanPasteForSender:(id)sender
 {
-	BOOL canPaste = [NSPasteboard.generalPasteboard canReadItemWithDataConformingToTypes:@[LNPropertyListNodePasteboardType, LNPropertyListNodeXcodeKeyType]];
+	BOOL canPaste = [NSPasteboard.generalPasteboard canReadItemWithDataConformingToTypes:@[LNPropertyListNodePasteboardReferenceType, LNPropertyListNodePasteboardValueType, LNPropertyListNodeXcodeKeyType]];
 	NSInteger row = [self _rowForSender:sender beep:NO];
 	id node = [self.outlineView itemAtRow:row] ?: self.rootPropertyListNode;
 	if(canPaste && _flags.delegate_canAddNewNodeInNode)

--- a/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListEditor.m
+++ b/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListEditor.m
@@ -942,12 +942,12 @@
 	id<NSPasteboardWriting> pbWriter = node.pasteboardWriter;
 	
 	[NSPasteboard.generalPasteboard clearContents];
+	[LNPropertyListNode _clearPasteboardMapping];
+
 	for (NSPasteboardType type in [pbWriter writableTypesForPasteboard:NSPasteboard.generalPasteboard])
 	{
 		[NSPasteboard.generalPasteboard setData:[node.pasteboardWriter pasteboardPropertyListForType:type] forType:type];
 	}
-	
-	[LNPropertyListNode _clearPasteboardMapping];
 }
 
 - (IBAction)paste:(id)sender

--- a/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListNode-Private.h
+++ b/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListNode-Private.h
@@ -11,7 +11,8 @@
 
 #import <AppKit/AppKit.h>
 
-extern NSString* const LNPropertyListNodePasteboardType;
+extern NSString* const LNPropertyListNodePasteboardReferenceType;
+extern NSString* const LNPropertyListNodePasteboardValueType;
 extern NSString* const LNPropertyListNodeXcodeKeyType;
 
 @interface LNPropertyListNode () <NSPasteboardReading>

--- a/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListNode.m
+++ b/LNPropertyListEditor/LNPropertyListEditor/Implementation/LNPropertyListNode.m
@@ -21,7 +21,7 @@ static NSMapTable<NSString*, LNPropertyListNode*>* _pasteboardNodeMapping;
 {
 	@autoreleasepool
 	{
-		_pasteboardNodeMapping = [NSMapTable strongToWeakObjectsMapTable];
+		_pasteboardNodeMapping = [NSMapTable strongToStrongObjectsMapTable];
 	}
 }
 
@@ -482,8 +482,16 @@ static NSMapTable<NSString*, LNPropertyListNode*>* _pasteboardNodeMapping;
 	rv.key = self.key;
 	rv.type = self.type;
 	rv.value = self.value;
-	rv.children = self.children.mutableCopy;
-	
+
+  if(self.children.count > 0)
+  {
+    rv.children = [[NSMutableArray alloc] initWithArray:self.children copyItems:YES];
+    for (LNPropertyListNode *child in rv.children)
+    {
+      child.parent = rv;
+    }
+  }
+
 	return rv;
 }
 
@@ -502,8 +510,8 @@ static NSMapTable<NSString*, LNPropertyListNode*>* _pasteboardNodeMapping;
 	{
 		NSDictionary* info = [NSPropertyListSerialization propertyListWithData:propertyList options:0 format:nil error:NULL];
 		NSString* UDIDString = info[@"UDID"];
-		rv = [_pasteboardNodeMapping objectForKey:UDIDString];
 		
+		rv = [[_pasteboardNodeMapping objectForKey:UDIDString] copy];
 		if(rv == nil)
 		{
 			rv = [NSKeyedUnarchiver unarchivedObjectOfClass:LNPropertyListNode.class fromData:info[@"data"] error:NULL];


### PR DESCRIPTION
This PR fixes #14.

### 1. Fixes issue with `NSKeyedUnarchiver` fault logs

#### Steps to reproduce:

1. Select a plist node and copy it via ⌘C

#### Observe:

> ***** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSString' (0x1e1780918) [/System/Library/Frameworks/Foundation.framework]' for key 'key', even though it was not explicitly included in the client allowed classes set: '{(
>     "'LNPropertyListNode' (0x104650df0) [~/Library/Developer/Xcode/DerivedData/LNPropertyListEditorExample-eoszcjiazyaglicebgfeoshkripr/Build/Products/Debug/LNPropertyListEditor.framework]"
> )}'. This will be disallowed in the future.**

### 2. Fixes exception when copying array/dictionary nodes

#### Steps to reproduce:

1. Select the `testDict`  or `test` array node
2. Copy via ⌘C, then paste via ⌘V

#### Observe:

An exception occurs: `***** -[__NSArrayM insertObject:atIndex:]: object cannot be nil**`. For me the app doesn’t crash, but the state of the editor is inconsistent. For example, attempting to sort by the `key` column results in a blank editor. 🙃 On my colleagues machine, it would crash.

ℹ️ The following are further issues that became apparent after addressing the above.

### 3. Copying a top-level key pastes with a duplicate name

#### Steps to reproduce:

1. Select the `CFBundleName` node
2. Copy via ⌘C, then paste via ⌘V

#### Observe:

The new key is the same as the original key.

![image](https://github.com/LeoNatan/LNPropertyListEditor/assets/870270/917c5dec-6ff0-495a-81c9-a24a021294d8)

#### Expected:

The new key should be named `CFBundleName - 2`

### 4. Odd behavior when copying array/dictionary nodes

#### Steps to reproduce:

1. Select the `testDict`  or `test` array node
2. Copy via ⌘C, then paste via ⌘V

#### Observe:

1. Only the copy (not the source) key can be expanded.
2. Attempting to expand the source will actually expand the copy.

#### Expected:

A "deep copy" of these "reference" type nodes should be performed such that each has its own identity. 

### 5. Restore Drag & Drop Feature

With all of the updates above (commits 1 and 2), drag and drop support broke.

#### Steps to reproduce

1. Drag `CFBundleName` down to move it to lower in the plist.

#### Observe:

The dragged node is duplicated (`CFBundleName - 2`) rather than moved.

#### Expected:

The item is moved, not copied, when dragging.

#### Solution:

The solution I came up with was to define two different pasteboard types depending on whether we’re looking for "reference" or "value" semantics.

```diff
- NSString* const LNPropertyListNodePasteboardType = @"com.LeoNatan.LNPropertyList.node";
+ /// A  property list node that should be written to the pasteboard with reference semantics.
+ ///
+ /// This is designed to be used primarily for drag operations where a specific reference is being manipulated.
+ NSString* const LNPropertyListNodePasteboardReferenceType = @"com.LeoNatan.LNPropertyList.node.reference";
+ /// A  property list node that should be written to the pasteboard with value semantics.
+ NSString* const LNPropertyListNodePasteboardValueType = @"com.LeoNatan.LNPropertyList.node.value";
```

We register dragged types with `LNPropertyListNodePasteboardReferenceType` so the specific item (or reference) is moved and not copied. 